### PR TITLE
update runtime dependencies for Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This program can also be viewed as a general framework for classifying video wit
 
 ####Dependencies
 
-`sudo apt install ffmpeg libopenblas-base libhdf5-serial-dev libgoogle-glog-dev` 
+`sudo apt install ffmpeg libopenblas-base libhdf5-serial-dev libgoogle-glog-dev libopencv-highgui2.4v5` 
 
 #####Additional 14.04 Dependencies
 


### PR DESCRIPTION
I run Ubuntu 16.04 (LTS) and installed from `miles-deep-cpu.v0.3.tgz`.
When I ran the binary, I got this error message:
```
./miles-deep-cpu: error while loading shared libraries: libopencv_highgui.so.2.4: cannot open shared object file: No such file or directory
```
Installing the `libopencv-highgui2.4v5` package fixed this.